### PR TITLE
remove search and nav header

### DIFF
--- a/src/data/projects.yml
+++ b/src/data/projects.yml
@@ -1,10 +1,10 @@
 categories:
   - title: Web development
-    url: //github.com/Esri
+    url: //github.com/search?q=topic%3Aweb-development+org%3AEsri+fork%3Atrue
     text: Explore more web projects
     projects:
       - title: City of Raleigh, North Carolina
-        description: The City of Raleigh used Esri Leaflet to help citizens quickly find nearby electric vehicle charging stations, green roofs, and solar trash compactors.
+        description: The City of Raleigh uses Esri Leaflet to help citizens quickly find nearby electric vehicle charging stations, green roofs, and solar trash compactors.
         image: /assets/img/projects/raleigh-sustainable.png
         url: //maps.raleighnc.gov/sustainable/
         language: JavaScript
@@ -20,7 +20,7 @@ categories:
         description: A Responsive HTML, CSS, and JS Framework.
         image: //developers.arcgis.com/assets/img/homepage/promo-python.png
         url: //esri.github.io/calcite-web/
-        language: CSS
+        language: css
         stars: 39
         text: Learn more
       - title: Cedar
@@ -38,7 +38,7 @@ categories:
         stars: 36
         text: Learn more
   - title: Data management
-    url: //github.com/Esri
+    url: //github.com/search?q=topic%3Adata-management+org%3AEsri+fork%3Atrue
     text: Explore more data management projects
     projects:
       - title: U.S. Census Bureau
@@ -76,7 +76,7 @@ categories:
         stars: 123
         text: Learn more about StoryMaps
   - title: Analysis
-    url: //github.com/Esri
+    url: //github.com/search?q=topic%3Aanalysis+org%3AEsri+fork%3Atrue
     text: Explore more analysis projects
     projects:
       - title: Gibbs Seed Company
@@ -115,7 +115,7 @@ categories:
         stars: 15
         text: Learn more
   - title: Publishing and sharing
-    url: //github.com/Esri
+    url: //github.com/search?q=topic%3Apublishing-sharing+org%3AEsri+fork%3Atrue
     text: Explore more publishing and sharing projects
     projects:
       - title: The Smithsonian

--- a/src/data/projects.yml
+++ b/src/data/projects.yml
@@ -7,34 +7,39 @@ categories:
         description: The City of Raleigh uses Esri Leaflet to help citizens quickly find nearby electric vehicle charging stations, green roofs, and solar trash compactors.
         image: /assets/img/projects/raleigh-sustainable.png
         url: //maps.raleighnc.gov/sustainable/
-        language: JavaScript
+        displayLang: JavaScript
+        searchLang: javascript
         text: Learn more
       - title: Esri Leaflet
         description: Leaflet plugins for the most popular ArcGIS web services
         image: //developers.arcgis.com/assets/img/homepage/promo-python.png
         url: //esri.github.io/esri-leaflet/
-        language: JavaScript
+        displayLang: JavaScript
+        searchLang: javascript
         stars: 691
         text: Learn more
       - title: Calcite Web
         description: A Responsive HTML, CSS, and JS Framework.
         image: //developers.arcgis.com/assets/img/homepage/promo-python.png
         url: //esri.github.io/calcite-web/
-        language: css
+        displayLang: CSS
+        searchLang: css
         stars: 39
         text: Learn more
       - title: Cedar
         description: Charts for ArcGIS GeoServices
         image: //developers.arcgis.com/assets/img/homepage/promo-python.png
         url: //esri.github.io/cedar/
-        language: JavaScript
+        displayLang: JavaScript
+        searchLang: javascript
         stars: 148
         text: Learn more
       - title: LERC
         description: rapid encoding and decoding for any pixel type (not just RGB or Byte)
         image: //developers.arcgis.com/assets/img/homepage/promo-python.png
         url: //github.com/Esri/lerc
-        language: C++
+        displayLang: C++
+        searchLang: c%2B%2B
         stars: 36
         text: Learn more
   - title: Data management
@@ -45,34 +50,39 @@ categories:
         description: The U.S. Census measures and shares national statistic data about every single household in the United States. To make the information accessible to application developers they developed CitySDK which uses the Terraformer library to convert between Esri JSON and GeoJSON.
         image: /assets/img/projects/us-census-citysdk.png
         url: //terraformer.io
-        language: JavaScript
+        displayLang: JavaScript
+        searchLang: javascript
         text: Learn more about Terraformer
       - title: Koop
         description: Node server to integrate custom Web APIs with ArcGIS.
         image: //developers.arcgis.com/assets/img/homepage/promo-python.png
         url: //koopjs.github.io/
-        language: JavaScript
+        displayLang: JavaScript
+        searchLang: javascript
         stars: 314
         text: Learn more about Koop
       - title: Geometry Engine
         description: Fundamental spatial data types and analyses
         image: //developers.arcgis.com/assets/img/homepage/promo-python.png
         url: //github.com/Esri/geometry-api-java/wiki
-        language: Java
+        displayLang: Java
+        searchLang: java
         stars: 242
         text: Learn more
       - title: Terraformer
         description: Library to convert common spatial data formats.
         image: //developers.arcgis.com/assets/img/homepage/promo-python.png
         url: //terraformer.io
-        language: JavaScript
+        displayLang: JavaScript
+        searchLang: javascript
         stars: 378
         text: Learn more about Terraformer
       - title: OSM Editor
         description: Desktop toolbox for accessing and editing OpenStreetMap.
         image: //developers.arcgis.com/assets/img/homepage/promo-python.png
         url: //github.com/Esri/arcgis-osm-editor
-        language: C#
+        displayLang: C#
+        searchLang: c%23
         stars: 123
         text: Learn more about StoryMaps
   - title: Analysis
@@ -83,35 +93,40 @@ categories:
         description: Gibbs Seed Company constantly monitors current agricultural conditions and appropriate seed hybrids for farmers to plant throughout their fields. Using Spark-Geo and PySAL they can analyze over 300 million planting options in under 10 minutes.
         image: /assets/img/projects/spark-geo.png
         url: //github.com/Esri/storymap-crowdsource
-        language: JavaScript
+        displayLang: C#
+        searchLang: c%23
         stars: 7
         text: Learn more about StoryMaps
       - title: GIS Tools for Hadoop
         description: Integrate ArcGIS with Hadoop big data processing.
         image: //developers.arcgis.com/assets/img/homepage/promo-python.png
         url: //github.com/Esri/gis-tools-for-hadoop
-        language: Java
+        displayLang: Java
+        searchLang: java
         stars: 289
         text: Learn more
       - title: R Analysis
         description: Develop and share R statistical analysis with ArcGIS.
         image: //developers.arcgis.com/assets/img/homepage/promo-python.png
         url: //r-arcgis.github.io/
-        language: R
+        displayLang: R
+        searchLang: r
         stars: 47
         text: Learn more
       - title: PySAL
         description: Python library for spatial analysis.
         image: //developers.arcgis.com/assets/img/homepage/promo-python.png
         url: //github.com/Esri/PySAL-ArcGIS-Toolbox
-        language: Python
+        displayLang: Python
+        searchLang: python
         stars: 7
         text: Learn more
       - title: Spark Point in Polygon
         description: Spark job to perform massive Point in Polygon (PiP) operations on a distributed share-nothing cluster.
         image: //developers.arcgis.com/assets/img/homepage/promo-python.png
         url: //github.com/mraad/spark-pip
-        language: Scala
+        displayLang: Scala
+        searchLang: scala
         stars: 15
         text: Learn more
   - title: Publishing and sharing
@@ -122,33 +137,38 @@ categories:
         description: The Smithsonian maintains vast archives of cultural heritage.  They use Story Maps to provide the rich history and spatial context of our world.
         image: /assets/img/projects/storymap-smithsonian.png
         url: //github.com/Esri/storymap-crowdsource
-        language: JavaScript
+        displayLang: JavaScript
+        searchLang: javascript
         text: Learn more
       - title: Compare Maps
         description: Web app for comparing different maps.
         image: //developers.arcgis.com/assets/img/homepage/promo-python.png
         url: //github.com/Esri/Compare-Maps-Template
-        language: JavaScript
+        displayLang: JavaScript
+        searchLang: javascript
         stars: 3
         text: Learn more
       - title: Historic Map Explorer
         description: Web app to explore digitized map overlays.
         image: //developers.arcgis.com/assets/img/homepage/promo-python.png
         url: //github.com/Esri/map-collection-explorer
-        language: JavaScript
+        displayLang: JavaScript
+        searchLang: javascript
         stars: 5
         text: Learn more
       - title: Open Data
         description: Web components for integrating data into civic sites.
         image: //developers.arcgis.com/assets/img/homepage/promo-python.png
         url: //github.com/esridc/opendata-search-component
-        language: JavaScript
+        displayLang: JavaScript
+        searchLang: javascript
         stars: 3
         text: Learn more
       - title: Styler
         description: A configurable application for creating, styling and sharing modern 2D and 3D map apps
         image: //developers.arcgis.com/assets/img/homepage/promo-python.png
         url: //github.com/Esri/calcite-maps-styler-template
-        language: JavaScript
+        displayLang: JavaScript
+        searchLang: javascript
         stars: 11
         text: Learn more

--- a/src/index.html
+++ b/src/index.html
@@ -13,12 +13,12 @@ css:
       <div class="text-center">
         <span class="esri-logo-reverse logo-large"></span>
       </div>
-      <h1 id="about" class="trailer-half">Esri Open Source</h1>
+      <h1 id="about" class="trailer-half">Esri <a href="http://www.esri.com/software/open/open-source">Open Source</a></h1>
       <p class="font-size-1">
         At Esri we believe that spatial thinking can address the world's most difficult problems and enable communities to work together. Central to our mission is the development of advanced technology that enables you to be innovative by providing a stable data management and analysis platform that is built and extended through open&#8209;source code.
       </p>
       <p class="font-size-1">
-        These projects cover the entire ArcGIS platform, from user applications to data analysis and visualization. Learn more about our many open-source products and tools that you are free to use, modify, contribute to. We look forward to working together.
+        These projects cover the entire ArcGIS platform, from user applications to data analysis and visualization. Learn more about our many open-source products and tools that you are free to use, modify and contribute to. We look forward to working together.
       </p>
       <p class="home-subscription-text">
         Need an <a href="//developers.esri.com/sign-up/" class="link-light-blue">ArcGIS subscription</a>? Start developing today for <a href="//developers.arcgis.com/plans/" class="link-light-blue">free</a>.
@@ -27,7 +27,7 @@ css:
   </main>
 </div>
 <div id="wrapper">
-  <div id="explore" class="grid-container">
+  <!--div id="explore" class="grid-container">
     <div class="filter-container column-18 pre-3 post-3 leader-0 trailer-1">
       <div class="label">
         <em class="lable-it">Find projects by language or keyword:</em>
@@ -43,7 +43,7 @@ css:
         </select>
       </div>
     </div>
-  </div>
+  </div-->
   <div class="grid-container">
     <div id="content" class="column-18 pre-3 post-3">
     </div>
@@ -52,7 +52,7 @@ css:
 <div id="featured" class="panel panel-no-padding panel-no-border padding-leader-2 padding-trailer-2">
   <div class="grid-container">
     <div class="column-24">
-      <h2 class="trailer-3">Featured projects</h2>
+      <!--h2 class="trailer-3">Featured projects</h2-->
       {% for project in data.projects.categories %}
         {{ projectsSection(project) }}
       {% endfor %}

--- a/src/index.html
+++ b/src/index.html
@@ -13,7 +13,7 @@ css:
       <div class="text-center">
         <span class="esri-logo-reverse logo-large"></span>
       </div>
-      <h1 id="about" class="trailer-half">Esri <a href="http://www.esri.com/software/open/open-source">Open Source</a></h1>
+      <h1 id="about" class="trailer-half">Esri <a class="link-white" href="http://www.esri.com/software/open/open-source">Open Source</a></h1>
       <p class="font-size-1">
         At Esri we believe that spatial thinking can address the world's most difficult problems and enable communities to work together. Central to our mission is the development of advanced technology that enables you to be innovative by providing a stable data management and analysis platform that is built and extended through open&#8209;source code.
       </p>

--- a/src/layouts/_layout.html
+++ b/src/layouts/_layout.html
@@ -121,7 +121,7 @@
       </nav>
     </div>
     <div class="wrapper">
-      <header class="top-nav fade-in">
+      <!--header class="top-nav fade-in">
         <a class="skip-to-content" href="#skip-to-content">Skip To Content</a>
         <div class="grid-container">
           <div class="column-24">
@@ -136,7 +136,7 @@
             </nav>
           </div>
         </div>
-      </header>
+      </header-->
       <div id="skip-to-content">
         {% block main %}{% endblock %}
       </div>

--- a/src/layouts/_macros.html
+++ b/src/layouts/_macros.html
@@ -9,7 +9,7 @@
     <div class="column-12">
       <h4>{{ project.title }}</h4>
       <p>{{ project.description }}</p>
-      <p><a href="{{ project.url }}" alt="{{ project.text }}">{{ project.text }} <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32" class="svg-icon"><path d="M7 4h5l12 12-12 12H7l12-12L7 4z"/></svg></a></p>
+      <!--p><a href="{{ project.url }}" alt="{{ project.text }}">{{ project.text }} <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32" class="svg-icon"><path d="M7 4h5l12 12-12 12H7l12-12L7 4z"/></svg></a></p-->
     </div>
   </div>
   <div class="block-group block-group-4-up tablet-block-group-2-up phone-block-group-1-up">
@@ -21,7 +21,7 @@
         <p class="card-last">{{ project.description }}</p>
         <p><a href="{{ project.url }}" alt="{{ project.text }}">{{ project.text }}<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32" class="svg-icon leader-2"><path d="M7 4h5l12 12-12 12H7l12-12L7 4z"/></svg></a></p>
         <footer>
-          <span class="font-size--2 text-green"><em>{{ project.language }}</em></span><span class="icon-star right padding-left-1 text-dark-gray font-size--2"><em>{{ project.stars }}</em></span>
+          <span class="font-size--2 link-green"><em><a href="https://github.com/Esri?language={{ project.language }}">{{ project.language }}</a></em></span><span class="icon-star right padding-left-1 text-dark-gray font-size--2"><em>{{ project.stars }}</em></span>
         </footer>
       </div>
     </div>

--- a/src/layouts/_macros.html
+++ b/src/layouts/_macros.html
@@ -21,7 +21,7 @@
         <p class="card-last">{{ project.description }}</p>
         <p><a href="{{ project.url }}" alt="{{ project.text }}">{{ project.text }}<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32" class="svg-icon leader-2"><path d="M7 4h5l12 12-12 12H7l12-12L7 4z"/></svg></a></p>
         <footer>
-          <span class="font-size--2 link-green"><em><a href="https://github.com/Esri?language={{ project.language }}">{{ project.language }}</a></em></span><span class="icon-star right padding-left-1 text-dark-gray font-size--2"><em>{{ project.stars }}</em></span>
+          <span class="font-size--2"><em><a class="link-green" href="https://github.com/Esri?language={{ project.searchLang }}">{{ project.displayLang }}</a></em></span><span class="icon-star right padding-left-1 text-dark-gray font-size--2"><em>{{ project.stars }}</em></span>
         </footer>
       </div>
     </div>


### PR DESCRIPTION
* removed navigation header and search box entirely.
* added a subdued hollerback to [esri.com/../open-source](http://www.esri.com/software/open/open-source)
* removed links from case-studies, since we don't have more info to share
* made language text in each card a link to https://github.com/esri?language=
* made the 'explore more category' links at the bottom of each section a hotlink to the same topic (ie: https://github.com/search?q=topic%3Aanalysis+org%3AEsri)

i'm actually pretty pleased with this.

to do:
- [X] ~~swap in encoded/properly cased language strings (display C++, link to C%2B%2B, display JavaScript, link to javascript~~
- [X] ~~keep language text green, even though its a link now~~
- [X] ~~improve color contrast in new title link~~